### PR TITLE
Improve compatibility with the One Login simulator

### DIFF
--- a/clients/nodejs/src/config/auth.ts
+++ b/clients/nodejs/src/config/auth.ts
@@ -20,7 +20,7 @@ const SCOPES = [
   "openid", // Always included
   "email", // Return the user's email address (NB: this is the username rather than their preferred communication email address) 
   "phone", // Return the user's telephone number
-  "offline_access" // Return a refresh token so the access token can be refreshed before it expires
+  // "offline_access" // Return a refresh token so the access token can be refreshed before it expires
 ];
 
 // Issuer that is must have issued identity claims.
@@ -80,7 +80,7 @@ async function getResult(
 
     // Check the validity of the claim using the public key
     const { payload } = await jwtVerify(coreIdentityJWT!, ivPublicKey, {
-      issuer: ISSUER,
+      issuer: client.issuer.metadata.issuer,
     });
 
     // Check the Vector of Trust (vot) to ensure the expected level of confidence was achieved.


### PR DESCRIPTION
# What
- remove ask for the refresh token by removing the offline_access scope (we are deprecating this)
- softcode the issuer in the claim validity check

# How to review
- run locally and ensure that it still works agains the integration environment
- configure to work with the simulator and ensure that it works as intended